### PR TITLE
Fix missing comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We are still early in development. There are quite a few pieces to AlphaGo that 
 >
 > -Silver et al. (page 8)
 
-For now you can only run some tests, as described in the ['Contributing'](CONTRIBUTING.md) document.
+For now, you can only run some tests, as described in the ['Contributing'](CONTRIBUTING.md) document.
 
 # How to contribute
 


### PR DESCRIPTION
A prepositional phrase that begins a sentence should be followed by a comma.