### PR TITLE
avoid WindowsError: [Error 32]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 !tests/test_data/sgf/*.sgf
 !tests/test_data/hdf5/*.h5
 !tests/test_data/hdf5/*.hdf5
+src/

--- a/AlphaGo/preprocessing/game_converter.py
+++ b/AlphaGo/preprocessing/game_converter.py
@@ -136,6 +136,7 @@ class game_converter:
 			print "finished. renaming %s to %s" % (tmp_file, hdf5_file)
 
 		# processing complete; rename tmp_file to hdf5_file
+		h5f.close()
 		os.rename(tmp_file, hdf5_file)
 
 


### PR DESCRIPTION
When I run the tests: "python -m unittest discover" in Windows, it meets "WindowsError: [Error 32]". I paste the output here.
Using Theano backend.
...EE................Epoch 1/1
960/960 [==============================] - 5s - loss: 0.3494 - val_loss: 0.3488
.
======================================================================
ERROR: test_directory_conversion (tests.test_game_converter.TestCmdlineConverter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "E:\codesource\AlphaGo\tests\test_game_converter.py", line 17, in test_directory_conversion
    run_game_converter(args)
  File "E:\codesource\AlphaGo\AlphaGo\preprocessing\game_converter.py", line 213, in run_game_converter
    converter.sgfs_to_hdf5(files, args.outfile, bd_size=args.size, verbose=args.verbose)
  File "E:\codesource\AlphaGo\AlphaGo\preprocessing\game_converter.py", line 139, in sgfs_to_hdf5
    os.rename(tmp_file, hdf5_file)
WindowsError: [Error 32]

======================================================================
ERROR: test_directory_walk (tests.test_game_converter.TestCmdlineConverter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "E:\codesource\AlphaGo\tests\test_game_converter.py", line 22, in test_directory_walk
    run_game_converter(args)
  File "E:\codesource\AlphaGo\AlphaGo\preprocessing\game_converter.py", line 213, in run_game_converter
    converter.sgfs_to_hdf5(files, args.outfile, bd_size=args.size, verbose=args.verbose)
  File "E:\codesource\AlphaGo\AlphaGo\preprocessing\game_converter.py", line 139, in sgfs_to_hdf5
    os.rename(tmp_file, hdf5_file)
WindowsError: [Error 32]

----------------------------------------------------------------------
Ran 22 tests in 19.448s

FAILED (errors=2)

Which is caused by the os.rename without close the file first.